### PR TITLE
Remove Pirated Link

### DIFF
--- a/docs/guide/install_melonx.md
+++ b/docs/guide/install_melonx.md
@@ -101,10 +101,10 @@ Once you've completed all the steps above, all you need to do is the following:
 To get around the current bugs with MeloNX, first you'll need to do the following:
 
 1. Find your prod.keys and title.keys file, then move them to the "System" folder in the MeloNX folder on your device. The MeloNX folder should be in your On My iPhone/iPad folder.
-2. Download [this](https://drive.google.com/file/d/1eF_OMuHxMBdqf5X5lMVyc24ds9YbOo3D/view?usp=sharing) file from Google Drive.
+2. Find your firmware and use [Ryujinx](https://ryujinx.app) on macOS, Linux or Windows to add your firmware then copy bis folder over to the device.
 3. Extract it, and then in your files app move the extracted folder to the MeloNX folder as well, and tap replace when it asks you to.
 4. Finally, if you are going to import any games, simply just move them into the ROMs folder within the MeloNX folder instead of importing them through the app. There is no say at the moment when these bugs will be fixed, but when they are, you will be able to import games through the app directly.
 
 ### You've now got JIT activated, and can play any Switch games you want once you import the ROMs!
 
-> **Note**: We will NOT give you websites or links to obtain Nintendo Switch rom files. You are on your own in obtaining them.
+> **Note**: We will NOT give you websites or links to obtain Nintendo Switch rom, firmware and keys files. You are on your own in obtaining them.


### PR DESCRIPTION
Downloading Firmware (bis folder) is illegal and Piracy, same as ROMs and keys.

1. Copyright Law

Nintendo Switch firmware is copyrighted software owned by Nintendo. Copyright law gives Nintendo the exclusive right to:

Reproduce the software
Distribute it
Create derivative works
When someone dumps the firmware from their Switch and shares it online, they are distributing copyrighted software without Nintendo’s permission — a violation of copyright law.

2. No License to Share

Even if you legally own a Nintendo Switch, the firmware is licensed to you, not sold. The license typically restricts copying or redistribution. Uploading it violates that license, and downloading it from someone else means you’re receiving software you have no legal right to possess unless it came directly from Nintendo.

3. Distribution = Piracy

When firmware is shared online, it’s considered pirated software by law. Downloading or using pirated firmware is illegal in most countries, including:

The U.S. (under the DMCA)
EU nations (under EU copyright directives)
Australia (under Copyright Act 1968)
4. Use in Emulators Doesn't Make It Legal

Even though MeloNX uses firmware that you can download, that doesn’t make it legal unless you dump the firmware yourself from hardware you own. Downloading someone else’s dump is still illegal, regardless of your intent.